### PR TITLE
Improve voice call STT, pin order, and chat disclaimer

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -303,7 +303,8 @@
 /* ============================
    FORMULARIO DE CHAT
 ============================ */
-.openai-chat-form textarea {
+.openai-chat-form textarea,
+.openai-chat-form-logged-out textarea {
   resize: none;
   line-height: 1.4;
   overflow-y: hidden;
@@ -312,35 +313,43 @@
   outline: none !important;
 }
 
-.openai-chat-form textarea::-webkit-input-placeholder {
+.openai-chat-form textarea::-webkit-input-placeholder,
+.openai-chat-form-logged-out textarea::-webkit-input-placeholder {
   line-height: 24px;
 }
 
-.openai-chat-form textarea::-moz-placeholder {
+.openai-chat-form textarea::-moz-placeholder,
+.openai-chat-form-logged-out textarea::-moz-placeholder {
   line-height: 24px;
 }
 
-.openai-chat-form textarea:-ms-input-placeholder {
+.openai-chat-form textarea:-ms-input-placeholder,
+.openai-chat-form-logged-out textarea:-ms-input-placeholder {
   line-height: 24px;
 }
 
-.openai-chat-form textarea::-ms-input-placeholder {
+.openai-chat-form textarea::-ms-input-placeholder,
+.openai-chat-form-logged-out textarea::-ms-input-placeholder {
   line-height: 24px;
 }
 
-.openai-chat-form textarea::placeholder {
+.openai-chat-form textarea::placeholder,
+.openai-chat-form-logged-out textarea::placeholder {
   line-height: 24px;
 }
 
-.openai-chat-form textarea:-moz-placeholder-shown {
+.openai-chat-form textarea:-moz-placeholder-shown,
+.openai-chat-form-logged-out textarea:-moz-placeholder-shown {
   line-height: 24px;
 }
 
-.openai-chat-form textarea:-ms-input-placeholder {
+.openai-chat-form textarea:-ms-input-placeholder,
+.openai-chat-form-logged-out textarea:-ms-input-placeholder {
   line-height: 24px;
 }
 
-.openai-chat-form textarea:placeholder-shown {
+.openai-chat-form textarea:placeholder-shown,
+.openai-chat-form-logged-out textarea:placeholder-shown {
   line-height: 24px;
 }
 
@@ -736,4 +745,30 @@ ul.am-agent-list li:first-child {
 @keyframes am-typing {
   0%,80%,100% { opacity: .2; transform: translateY(0); }
   40% { opacity: 1; transform: translateY(-3px); }
+}
+
+.am-coach-note {
+  font-size: 12px;
+  color: #555;
+  margin-top: 6px;
+  display: flex;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.am-coach-note .am-coach-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 0 0 0 4px;
+}
+
+.am-coach-note .am-coach-full {
+  display: none;
+}
+
+.am-coach-note.expanded .am-coach-full {
+  display: inline;
 }

--- a/assets/js/conversations.js
+++ b/assets/js/conversations.js
@@ -72,6 +72,7 @@
           existing.classList.add('pinned');
           const btn = existing.querySelector('.am-pin-btn');
           if (btn) btn.innerHTML = PIN_ICON + 'Unpin';
+          list.insertBefore(existing, list.firstChild);
           return;
         }
         const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- Add SpeechRecognition fallback and restart logic to stabilize STT voice calls
- Move pinned assistants to the top of the list and preserve on reload
- Toggle chat form class for logged-in state and add collapsible disclaimer beneath input

## Testing
- `php -l includes/shortcodes.php`
- `node --check assets/js/chat.js`
- `node --check assets/js/conversations.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5c994e59c8324bcb92217715748b4