### PR TITLE
Fix coach note layout and voice call visuals

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -479,16 +479,15 @@
 
 .am-voice-call-overlay .am-voice-level {
   position: absolute;
-  top: 50%;
+  bottom: 0;
   left: 50%;
-  width: 160px;
+  width: 100%;
   height: 160px;
-  border-radius: 50%;
-  background: -o-radial-gradient(circle, #B3AAE4 0%, rgb(91 80 134) 50%, rgb(91 80 134) 100%);
+  border-radius: 0;
   background: radial-gradient(circle, #B3AAE4 0%, rgb(91 80 134) 50%, rgb(91 80 134) 100%);
-  -webkit-transform: translate(-50%, -50%) scale(1);
-      -ms-transform: translate(-50%, -50%) scale(1);
-          transform: translate(-50%, -50%) scale(1);
+  -webkit-transform: translateX(-50%) scale(1);
+      -ms-transform: translateX(-50%) scale(1);
+          transform: translateX(-50%) scale(1);
   -webkit-transition: -webkit-transform .2s;
   transition: -webkit-transform .2s;
   -o-transition: transform .2s;
@@ -752,17 +751,25 @@ ul.am-agent-list li:first-child {
   color: #555;
   margin-top: 6px;
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .am-coach-note .am-coach-toggle {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 12px;
   line-height: 1;
-  padding: 0 0 0 4px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.am-coach-note .am-coach-icon {
+  width: 10px;
+  height: 10px;
+  transition: transform .2s;
 }
 
 .am-coach-note .am-coach-full {
@@ -771,4 +778,8 @@ ul.am-agent-list li:first-child {
 
 .am-coach-note.expanded .am-coach-full {
   display: inline;
+}
+
+.am-coach-note.expanded .am-coach-icon {
+  transform: rotate(180deg);
 }

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -29,7 +29,6 @@
         toggle.addEventListener('click', () => {
           const expanded = disclaimer.classList.toggle('expanded');
           full.style.display = expanded ? '' : 'none';
-          toggle.innerHTML = expanded ? '\u25B2' : '\u25BC';
         });
       }
     }

--- a/assets/js/conversations.js
+++ b/assets/js/conversations.js
@@ -225,6 +225,8 @@
           const updated = pins.filter(p => String(p.id) !== String(id));
           savePins(updated);
           item.classList.remove('pinned');
+          const list = item.parentElement;
+          if (list) list.appendChild(item);
         } else {
           const data = {
             id,

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -95,11 +95,11 @@ add_shortcode('am_chat', function(){
 </svg>
 </button>
       </div>
-      <div class="am-coach-note">
-        <span class="am-coach-short">This is an AI-based life coach, trained on modern psychology.</span>
-        <span class="am-coach-full"> It’s not therapy or a substitute for professional care. But it can help you move forward — one real step at a time.</span>
-        <button type="button" class="am-coach-toggle" aria-label="Toggle disclaimer">&#x25BC;</button>
-      </div>
+        <p class="am-coach-note">
+          <span class="am-coach-short">This is an AI-based life coach, trained on modern psychology…</span>
+          <span class="am-coach-full"> It’s not therapy or a substitute for professional care. But it can help you move forward — one real step at a time.</span>
+          <button type="button" class="am-coach-toggle" aria-label="Toggle disclaimer"><img src="https://wa4u.ai/wp-content/uploads/2025/08/nav-arrow-down.svg" alt="Toggle" class="am-coach-icon"></button>
+        </p>
       <input type="hidden" name="agent_id" value="<?php echo esc_attr($agent_id); ?>">
     </form>
 
@@ -194,9 +194,9 @@ add_shortcode('am_chat', function(){
         if (!micAnalyser || !levelCircle) return;
         if (micVizInterval) clearInterval(micVizInterval);
         micVizInterval = setInterval(()=>{
-          const lvl = micLevel();
-          const scale = 1 + Math.min(0.3, lvl*2);
-          levelCircle.style.transform = `translate(-50%, -50%) scale(${scale.toFixed(2)})`;
+            const lvl = micLevel();
+            const scale = 1 + Math.min(0.3, lvl*2);
+            levelCircle.style.transform = `translateX(-50%) scale(${scale.toFixed(2)})`;
         },100);
       }
 
@@ -216,16 +216,16 @@ add_shortcode('am_chat', function(){
         ttsAnalyser.connect(ttsCtx.destination);
         ttsData = new Uint8Array(ttsAnalyser.fftSize);
         ttsVizInterval = setInterval(()=>{
-          ttsAnalyser.getByteTimeDomainData(ttsData);
-          let sum = 0;
-          for (let i=0;i<ttsData.length;i++){ const v = (ttsData[i]-128)/128; sum += v*v; }
-          const lvl = Math.sqrt(sum/ttsData.length);
-          const scale = 1 + Math.min(0.3, lvl*2);
-          levelCircle.style.transform = `translate(-50%, -50%) scale(${scale.toFixed(2)})`;
+            ttsAnalyser.getByteTimeDomainData(ttsData);
+            let sum = 0;
+            for (let i=0;i<ttsData.length;i++){ const v = (ttsData[i]-128)/128; sum += v*v; }
+            const lvl = Math.sqrt(sum/ttsData.length);
+            const scale = 1 + Math.min(0.3, lvl*2);
+            levelCircle.style.transform = `translateX(-50%) scale(${scale.toFixed(2)})`;
         },100);
         const clear = () => {
-          clearInterval(ttsVizInterval); ttsVizInterval=null; levelCircle.style.transform='translate(-50%, -50%) scale(1)';
-          if (ttsCtx) {
+            clearInterval(ttsVizInterval); ttsVizInterval=null; levelCircle.style.transform='translateX(-50%) scale(1)';
+            if (ttsCtx) {
             ttsCtx.close().catch(()=>{});
             ttsCtx = null;
           }
@@ -456,6 +456,7 @@ add_shortcode('am_chat', function(){
             sr = new SR();
             sr.lang = lang;
             sr.interimResults = false;
+            sr.continuous = true;
             sr.onresult = async (e) => {
               const text = (e.results[0][0]?.transcript || '').trim();
               if (text) {
@@ -536,7 +537,7 @@ add_shortcode('am_chat', function(){
         if (ttsVizInterval){ clearInterval(ttsVizInterval); ttsVizInterval=null; }
         if (ttsCtx){ ttsCtx.close().catch(()=>{}); ttsCtx=null; }
         if (avatarImg) avatarImg.style.transform='scale(1)';
-        if (levelCircle) levelCircle.style.transform='translate(-50%, -50%) scale(1)';
+        if (levelCircle) levelCircle.style.transform='translateX(-50%) scale(1)';
         if (micStream){ micStream.getTracks().forEach(t=>t.stop()); micStream=null; }
         if (mediaRecorder && mediaRecorder.stream){ mediaRecorder.stream.getTracks().forEach(t=> t.stop()); }
         mediaRecorder = null;


### PR DESCRIPTION
## Summary
- display coach note as single-line paragraph with toggleable full text and custom arrow icon
- reposition unpinned assistants to end of list
- anchor voice level meter to bottom of call overlay and enable continuous speech recognition

## Testing
- `php -l includes/shortcodes.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5ce27cd208324826bf37fadd204cb