### PR TITLE
Center call UI and restore recording controls

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -456,16 +456,19 @@
   display: -ms-grid;
   display: grid;
   place-content: center;
+  place-items: center;
   gap: 32px;
   color: #fff;
   text-align: center;
 }
 
 
+
 .am-voice-call-overlay .am-voice-avatar-wrap {
   position: relative;
   width: 160px;
   height: 160px;
+  margin: 0 auto;
   z-index: 1;
 }
 
@@ -477,12 +480,13 @@
      object-fit: cover;
 }
 
+
 .am-voice-call-overlay .am-voice-level {
   position: absolute;
-  bottom: 0;
+  bottom: -50%;
   left: 50%;
   width: 100%;
-  height: 160px;
+  height: 100%;
   border-radius: 0;
   background: radial-gradient(circle, #B3AAE4 0%, rgb(91 80 134) 50%, rgb(91 80 134) 100%);
   -webkit-transform: translateX(-50%) scale(1);
@@ -493,12 +497,15 @@
   -o-transition: transform .2s;
   transition: transform .2s;
   transition: transform .2s, -webkit-transform .2s;
-  z-index: 0;
+  z-index: -1;
   pointer-events: none;
 }
 
 .am-voice-call-overlay .assistant-meta {
   text-align: center;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
 }
 
 .am-voice-call-overlay .assistant-name {
@@ -524,7 +531,13 @@
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   gap: 16px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
 }
 
 .am-voice-call-controls button {

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -226,7 +226,6 @@
           isRecording = true;
           updateVoiceBtn('listening');
           if (sttOverlay) { sttOverlay.innerHTML = 'Listening...'; sttOverlay.style.display = 'flex'; }
-          if (voiceBtn) voiceBtn.style.display = 'none';
           if (sendBtn) sendBtn.style.display = 'none';
           if (callBtn) callBtn.style.display = 'none';
           sr.start();
@@ -323,6 +322,15 @@
         if (!isRecording) return;
         isRecording = false;
         if (sr) {
+          if (sttOverlay) {
+            sttOverlay.innerHTML = transcribingImg
+              ? `<img src="${transcribingImg}" alt="Transcribing...">`
+              : 'Thinking...';
+            sttOverlay.style.display = 'flex';
+          }
+          if (voiceBtn) voiceBtn.style.display = 'none';
+          if (sendBtn) sendBtn.style.display = 'none';
+          if (callBtn) callBtn.style.display = 'none';
           try { sr.stop(); } catch (_) {}
           return;
         }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -301,7 +301,7 @@ add_shortcode('am_chat', function(){
 
                   // ✅ Re-enciende el medidor y garantiza recorder activo
                   if (!micMuted) startMicViz();
-                  if (!mediaRecorder || mediaRecorder.state !== 'recording') {
+                  if (overlay.style.display === 'grid' && !micMuted && (!mediaRecorder || mediaRecorder.state !== 'recording')) {
                     startRecognition();
                   }
                 }
@@ -321,7 +321,7 @@ add_shortcode('am_chat', function(){
               if (overlay.style.display !== 'none' && !micMuted) startMicViz();
 
               // ✅ Asegura que seguimos grabando tras TTS
-              if (!mediaRecorder || mediaRecorder.state !== 'recording') {
+              if (overlay.style.display === 'grid' && !micMuted && (!mediaRecorder || mediaRecorder.state !== 'recording')) {
                 startRecognition();
               }
 
@@ -374,7 +374,7 @@ add_shortcode('am_chat', function(){
           setState('Idle');
         }
         busy = false;
-        if (!mediaRecorder || mediaRecorder.state !== 'recording') {
+        if (overlay.style.display === 'grid' && !micMuted && (!mediaRecorder || mediaRecorder.state !== 'recording')) {
           startRecognition();
         }
         if (pendingChunk && !busy) {
@@ -450,38 +450,6 @@ add_shortcode('am_chat', function(){
 
       async function startRecognition(){
         lang = document.querySelector('.openai-chat-container')?.dataset?.sttLang || 'en-US';
-        const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
-        if (SR) {
-          try {
-            sr = new SR();
-            sr.lang = lang;
-            sr.interimResults = false;
-            sr.continuous = true;
-            sr.onresult = async (e) => {
-              const text = (e.results[0][0]?.transcript || '').trim();
-              if (text) {
-                setState('Processing');
-                await askAssistant(text, true);
-              }
-            };
-            sr.onerror = () => {
-              logMessage('system', 'STT error');
-              sr = null;
-              startWhisperRecognition();
-            };
-            sr.onend = () => {
-              sr = null;
-              if (overlay.style.display === 'grid' && !micMuted && !busy) {
-                startRecognition();
-              }
-            };
-            setState('Listening');
-            sr.start();
-            return;
-          } catch(_) {
-            sr = null;
-          }
-        }
         await startWhisperRecognition();
       }
 


### PR DESCRIPTION
## Summary
- Center call overlay elements and adjust audio level indicator layering
- Use Whisper-only speech recognition and guard against background listening after calls
- Restore record-off button with thinking state during voice input

## Testing
- `php -l includes/shortcodes.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5d30e0fd88324958947c56f60b268