### PR TITLE
Keep voice recording active until manually stopped

### DIFF
--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -214,7 +214,12 @@
             }
           };
           sr.onerror = (e) => console.error('SR error:', e);
+          sr.continuous = true;
           sr.onend = () => {
+            if (isRecording) {
+              try { sr.start(); } catch (_) {}
+              return;
+            }
             if (sttOverlay) sttOverlay.style.display = 'none';
             if (voiceBtn) voiceBtn.style.display = '';
             if (sendBtn) sendBtn.style.display = '';


### PR DESCRIPTION
## Summary
- prevent speech recognition from stopping automatically
- resume voice capture when the browser ends the session

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5d537367c8324abcde875d6cd6bdb