### PR TITLE
Refine chat scroll and coach note toggle

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -772,10 +772,11 @@ ul.am-agent-list li:first-child {
 }
 
 .am-coach-note .am-coach-short {
-  flex: 1;
+  flex: 0 1 auto;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: calc(100% - 34px);
 }
 
 .am-coach-note .am-coach-toggle {
@@ -787,8 +788,8 @@ ul.am-agent-list li:first-child {
 }
 
 .am-coach-note .am-coach-icon {
-  width: 10px;
-  height: 10px;
+  width: 30px;
+  height: 30px;
   transition: transform .2s;
 }
 

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -139,7 +139,7 @@
         }
         if (!added) return;
 
-        if (!userLocked) {
+        if (!initialLoad && !userLocked) {
           scrollToBottom(true);
         }
         updateState();
@@ -859,12 +859,11 @@ function extractSuggestions(raw, replyOrRaw) {
       messagesEl.appendChild(wrap);
 
       if (role === 'ai') {
-        if (!initialLoad) {
-          if (root.AM_setUserLocked) root.AM_setUserLocked(false);
-          if (root.AM_scrollToBottom) root.AM_scrollToBottom(true);
-        }
-      } else if (shouldStick && root.AM_scrollToBottom) {
-        root.AM_scrollToBottom(true);
+        if (!initialLoad && root.AM_setUserLocked) root.AM_setUserLocked(false);
+        if (!initialLoad && root.AM_scrollToBottom) root.AM_scrollToBottom(true);
+      } else {
+        if (root.AM_setUserLocked) root.AM_setUserLocked(false);
+        if (root.AM_scrollToBottom) root.AM_scrollToBottom(true);
       }
       return wrap;
     }


### PR DESCRIPTION
## Summary
- Avoid scrolling to the bottom on initial page load; scroll only when new messages are sent or received
- Enlarge coach disclaimer toggle icon and place button directly after the text

## Testing
- `node --check assets/js/chat.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b81ee1673883248e0c38b8692a5afc