### PR TITLE
Fix chat form classes, prevent initial scroll, and refine disclaimer

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -772,7 +772,7 @@ ul.am-agent-list li:first-child {
 }
 
 .am-coach-note .am-coach-short {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -795,10 +795,19 @@ ul.am-agent-list li:first-child {
 
 .am-coach-note .am-coach-full {
   display: none;
+  flex: 1 1 auto;
+}
+
+.am-coach-note.expanded {
+  align-items: flex-start;
+}
+
+.am-coach-note.expanded .am-coach-short {
+  display: none;
 }
 
 .am-coach-note.expanded .am-coach-full {
-  display: inline;
+  display: block;
 }
 
 .am-coach-note.expanded .am-coach-icon {

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -162,7 +162,7 @@
     // -----------------------
     // Bienvenida (después de montar auto-scroll)
     // -----------------------
-    appendBubble('ai', escapeHtml(welcome), true);
+    appendBubble('ai', escapeHtml(welcome), true, true);
     initialLoad = false;
 
     // -----------------------
@@ -325,7 +325,7 @@
             const cleanedText = it.role === 'user'
               ? escapeHtml(String(it.content || ''))
               : sanitizeReply(String(it.content || ''));
-            const wrap = appendBubble(it.role === 'user' ? 'user' : 'ai', cleanedText, it.role !== 'user');
+            const wrap = appendBubble(it.role === 'user' ? 'user' : 'ai', cleanedText, it.role !== 'user', true);
 
             if (it.role !== 'user') {
               const mid = it.assistant_message_id || it.message_id || it.id;
@@ -819,7 +819,7 @@ function extractSuggestions(raw, replyOrRaw) {
 
 
 
-    function appendBubble(role, html, withPlay) {
+    function appendBubble(role, html, withPlay, skipScroll = false) {
       // Check if the user was near the bottom before adding the bubble
       const shouldStick = root.AM_isNearBottom ? root.AM_isNearBottom() : true;
 
@@ -859,11 +859,11 @@ function extractSuggestions(raw, replyOrRaw) {
       messagesEl.appendChild(wrap);
 
       if (role === 'ai') {
-        if (!initialLoad && root.AM_setUserLocked) root.AM_setUserLocked(false);
-        if (!initialLoad && root.AM_scrollToBottom) root.AM_scrollToBottom(true);
+        if (!initialLoad && !skipScroll && root.AM_setUserLocked) root.AM_setUserLocked(false);
+        if (!initialLoad && !skipScroll && root.AM_scrollToBottom) root.AM_scrollToBottom(true);
       } else {
-        if (root.AM_setUserLocked) root.AM_setUserLocked(false);
-        if (root.AM_scrollToBottom) root.AM_scrollToBottom(true);
+        if (!skipScroll && root.AM_setUserLocked) root.AM_setUserLocked(false);
+        if (!skipScroll && root.AM_scrollToBottom) root.AM_scrollToBottom(true);
       }
       return wrap;
     }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -54,7 +54,7 @@ add_shortcode('am_chat', function(){
     $user_name = $cu->display_name ?: $cu->user_login;
     $user_email = $cu->user_email;
   }
-  $form_class = is_user_logged_in() ? 'openai-chat-form' : 'openai-chat-form-logged-out';
+  $form_class = 'openai-chat-form' . (is_user_logged_in() ? '' : ' openai-chat-form-logged-out');
   ob_start(); ?>
   <div id="amc-<?php echo esc_attr($uid); ?>" class="openai-chat-container"
        data-agent-id="<?php echo esc_attr($agent_id); ?>"


### PR DESCRIPTION
## Summary
- keep `openai-chat-form` class when logged out
- avoid automatic scroll on initial page load
- improve disclaimer toggle layout

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b8232a9bd88324b6e270a7f61e6c98